### PR TITLE
Fix main in packages.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "build": "node build.js",
     "develop": "done-serve --static --develop --port 8080"
   },
-  "main": "dist/cjs/can-key-tree",
+  "main": "can-key-tree",
   "keywords": [
     "CanJS",
     "DoneJS",


### PR DESCRIPTION
The actual main in package.json `main: "dist/cjs/can-key-tree"` throws an error: `define  is not defined` if used without module loader like tests in [done-ssr](https://github.com/donejs/done-ssr/pulls).

This fixes the issue by updating `main` to the package main file `can-key-tree.js`.